### PR TITLE
Frontend bundler: various fixes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,10 +54,10 @@
         };
 
         packagingOverlay = final: prev:
-          let callService = { frontend, backend, pname, version, nix-lint-source, extra-checks ? {}, tree-shaking ? true }:
+          let callService = { frontend, backend, pname, version, nix-lint-source, extra-checks ? {}, tree-shaking ? false }:
                 serviceOutputs (prepareService { inherit frontend backend pname version nix-lint-source tree-shaking; }) extra-checks;
 
-              prepareService = { frontend, backend, pname, version, nix-lint-source, tree-shaking ? true }:
+              prepareService = { frontend, backend, pname, version, nix-lint-source, tree-shaking ? false }:
                 rec
                   {
                     frontendPackage = final.valdaro.frontend.callPackage frontend { inherit pname version tree-shaking; };

--- a/frontend/bundle.nix
+++ b/frontend/bundle.nix
@@ -11,7 +11,7 @@
 , src
 , spagoPackages    ? "${src}/spago-packages.nix"
 , nodeDependencies ? "${src}/node-dependencies.nix"
-, tree-shaking     ? true
+, tree-shaking     ? false
 }:
 
 let spagoPkgs = callPackage spagoPackages {};

--- a/frontend/bundle.nix
+++ b/frontend/bundle.nix
@@ -56,7 +56,7 @@ in stdenv.mkDerivation {
       copy-css-modules "${finalOutput}" "$src/src"
       cp ${./boot.js} ${finalOutput}/boot.js
 
-      esbuild --platform=browser --format=esm --loader:.css=local-css --loader:.js=jsx --bundle --minify --outfile="$distDirectory/bundle.js" ${finalOutput}/boot.js
+      esbuild --platform=browser --format=esm --loader:.js=jsx --bundle --minify --outfile="$distDirectory/bundle.js" ${finalOutput}/boot.js
     '';
 
     installPhase = ''

--- a/frontend/bundler.nix
+++ b/frontend/bundler.nix
@@ -22,7 +22,7 @@ writeShellApplication {
     distDirectory="dist"
 
     function bundle {
-      esbuild --platform=browser --format=esm --loader:.css=local-css --loader:.js=jsx --bundle "$@"
+      esbuild --platform=browser --format=esm --loader:.js=jsx --bundle "$@"
     }
 
     if [ "''${1-}" == "dev-server" ]

--- a/frontend/bundler.nix
+++ b/frontend/bundler.nix
@@ -22,7 +22,7 @@ writeShellApplication {
     distDirectory="dist"
 
     function bundle {
-      esbuild --platform=browser --format=esm --loader:.css=local-css --bundle "$@"
+      esbuild --platform=browser --format=esm --loader:.css=local-css --loader:.js=jsx --bundle "$@"
     }
 
     if [ "''${1-}" == "dev-server" ]
@@ -32,6 +32,8 @@ writeShellApplication {
       then
         cp ${./live-reload.js} output/live-reload.js
       fi
+
+      copy-css-modules "output"
 
       bundle --watch --servedir="./assets" --outfile="assets/bundle.js" output/live-reload.js
 
@@ -44,11 +46,11 @@ writeShellApplication {
 
       cp -r assets/. "$distDirectory"
 
+      copy-css-modules "dce-output"
+
       spago build --purs-args '--codegen corefn,js'
 
-      zephyr -f Main.main
-
-      copy-css-modules "dce-output"
+      zephyr --codegen corefn,js --dce-foreign Main.main
 
       bundle --minify --outfile="$distDirectory/bundle.js" dce-output/boot.js
     fi

--- a/frontend/bundler.nix
+++ b/frontend/bundler.nix
@@ -38,21 +38,21 @@ writeShellApplication {
       bundle --watch --servedir="./assets" --outfile="assets/bundle.js" output/live-reload.js
 
     else
-      mkdir -p dce-output
-      if [ ! -r dce-output/boot.js ]
+      mkdir -p output
+      if [ ! -r output/boot.js ]
       then
-        cp ${./boot.js} dce-output/boot.js
+        cp ${./boot.js} output/boot.js
       fi
 
       cp -r assets/. "$distDirectory"
 
-      copy-css-modules "dce-output"
+      copy-css-modules "output"
 
       spago build --purs-args '--codegen corefn,js'
 
-      zephyr --codegen corefn,js --dce-foreign Main.main
+      # zephyr --codegen corefn,js --dce-foreign Main.main
 
-      bundle --minify --outfile="$distDirectory/bundle.js" dce-output/boot.js
+      bundle --minify --outfile="$distDirectory/bundle.js" output/boot.js
     fi
   '';
 }

--- a/frontend/copy-css-modules.sh
+++ b/frontend/copy-css-modules.sh
@@ -19,11 +19,11 @@ function listModules {
 
 function copyCssModule {
   local module="$1"
-  cssModule="$(echo "$module" | sed -e 's-\.-/-' -e 's/$/.css/')"
+  cssModule="$(echo "$module" | sed -e 's-\.-/-' -e 's/$/.module.css/')"
   if [ -r "$src/$cssModule" ]
   then
     echo Copying css module for "$module"
-    cp "$src/$cssModule" "$outputDirectory/$module/$module.css"
+    cp "$src/$cssModule" "$outputDirectory/$module/$module.module.css"
   fi
 }
 


### PR DESCRIPTION
Following some tests (and notably trying to use [purescript-mantine](https://github.com/funky-thunks/purescript-mantine)), it appears the frontend bundler is far from perfection. Let's improve it:

### 1. Consistency of bundling processes

The `valdaro-bundler` script (notably used for `dev-server`) wasn't consistent with the nix derivation.

This should be fixed by using the same script base for both at some point.

### 2. CSS modules

Let's stick to defaults, shall we? They simply work.

- Global by default (supports importing styles from deps)
- Local for '.module.css' files

### 3. Zephyr is messy with foreign files

Let's disable it for now. esbuild is already tree shaking quite a bit.